### PR TITLE
[ADD]

### DIFF
--- a/choreograph-addons/choreograph_sale/i18n/fr.po
+++ b/choreograph-addons/choreograph_sale/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e-20221017\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-02 11:15+0000\n"
-"PO-Revision-Date: 2023-02-02 11:15+0000\n"
+"POT-Creation-Date: 2023-02-07 06:51+0000\n"
+"PO-Revision-Date: 2023-02-07 06:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -81,11 +81,6 @@ msgid "Attachment Count"
 msgstr ""
 
 #. module: choreograph_sale
-#: model:ir.model.fields,field_description:choreograph_sale.field_retribution_base_line__base_id
-msgid "Base"
-msgstr ""
-
-#. module: choreograph_sale
 #: model_terms:ir.ui.view,arch_db:choreograph_sale.view_order_form_inherit
 msgid "BAT"
 msgstr ""
@@ -94,6 +89,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:choreograph_sale.field_sale_order__bat_comment
 msgid "BAT Comment"
 msgstr "Commentaire"
+
+#. module: choreograph_sale
+#: model:ir.model.fields,field_description:choreograph_sale.field_retribution_base_line__base_id
+msgid "Base"
+msgstr ""
 
 #. module: choreograph_sale
 #: model:ir.model.fields,field_description:choreograph_sale.field_sale_order__bat_client
@@ -500,6 +500,16 @@ msgid "Portal Access URL"
 msgstr ""
 
 #. module: choreograph_sale
+#: model:ir.model.fields,field_description:choreograph_sale.field_retribution_base__postal_variable
+msgid "Postal Variable"
+msgstr "Variable Postale"
+
+#. module: choreograph_sale
+#: model:ir.model.fields,field_description:choreograph_sale.field_retribution_base__postal_address
+msgid "Postal address (DSP)"
+msgstr "Adresse Postale (DSP)"
+
+#. module: choreograph_sale
 #: model:ir.model.fields,field_description:choreograph_sale.field_sale_order__prefulfill_study
 msgid "Pre-fulfill study"
 msgstr "Prefulfill Etude"
@@ -572,11 +582,6 @@ msgstr "N° tâche"
 #: model:ir.model.fields,field_description:choreograph_sale.field_retribution_base__retribution_rate
 msgid "Retribution Rate"
 msgstr "Taux de rétribution"
-
-#. module: choreograph_sale
-#: model:ir.model.fields,field_description:choreograph_sale.field_retribution_base__retribution_rate_multi_base
-msgid "Retribution Rate (2)"
-msgstr "Taux de rétribution (2)"
 
 #. module: choreograph_sale
 #: model:ir.actions.act_window,name:choreograph_sale.retribution_base_action

--- a/choreograph-addons/choreograph_sale/models/retribution_base.py
+++ b/choreograph-addons/choreograph_sale/models/retribution_base.py
@@ -14,13 +14,15 @@ class RetributionBase(models.Model):
     is_multi_base = fields.Boolean('Multi-Bases', tracking=True)
     retribution_rate = fields.Float('Retribution Rate', tracking=True)
     quota_base_ids = fields.One2many('retribution.base.line', 'multi_base_id', 'Quotas', tracking=True)
-    retribution_rate_multi_base = fields.Float('Retribution Rate (2)', tracking=True, default=0.3)
+    postal_variable = fields.Float('Postal Variable', tracking=True, default=0.3)
+    postal_address = fields.Float('Postal address (DSP)', tracking=True, default=1.0)
 
     @api.onchange('quota_base_ids', 'is_multi_base')
     def _onchange_quota_base(self):
         self.retribution_rate = 0
         if self.is_multi_base:
-            self.retribution_rate = sum([qb.volume_percentage * qb.retribution_percentage for qb in self.quota_base_ids]) / 100
+            self.retribution_rate = sum(
+                [qb.volume_percentage * qb.retribution_percentage for qb in self.quota_base_ids]) / 100
             total_volume = sum(self.quota_base_ids.mapped('volume'))
             if total_volume:
                 for qb in self.quota_base_ids:

--- a/choreograph-addons/choreograph_sale/models/sale_order_line.py
+++ b/choreograph-addons/choreograph_sale/models/sale_order_line.py
@@ -19,7 +19,9 @@ class SaleOrderLine(models.Model):
             if rec.product_id.concerned_base:
                 rec.retribution_cost = rec.product_uom_qty * rec.price_unit * rec.product_id.concerned_base.retribution_rate
                 if rec.product_id.concerned_base.is_multi_base:
-                    rec.retribution_cost *= rec.product_id.concerned_base.retribution_rate_multi_base
+                    is_dsp = rec.product_id.default_code and rec.product_id.default_code[:3] == "DSP"
+                    rate = rec.product_id.concerned_base.postal_address if is_dsp else rec.product_id.concerned_base.postal_variable
+                    rec.retribution_cost *= rate
             else:
                 rec.retribution_cost = 0
 

--- a/choreograph-addons/choreograph_sale/views/retribution_base_views.xml
+++ b/choreograph-addons/choreograph_sale/views/retribution_base_views.xml
@@ -35,8 +35,11 @@
                                 <field name="retribution_rate" attrs="{'readonly':[('is_multi_base', '=', True)]}"
                                        force_save="1"
                                        widget="percentage"/>
-                                <field name="retribution_rate_multi_base" attrs="{'invisible':[('is_multi_base', '=', False)]}"
+                                <field name="postal_variable" attrs="{'invisible':[('is_multi_base', '=', False)]}"
                                        force_save="1"
+                                       widget="percentage"/>
+                                <field name="postal_address" attrs="{'invisible':[('is_multi_base', '=', False)]}"
+                                       readonly="1"
                                        widget="percentage"/>
                             </group>
                         </group>


### PR DESCRIPTION
Ajout champ Adresse Postale (DSP) avec une valeur par défaut 1.0 et non modifiable 
Changement champ taux de rétribution (2) en Variable postal 
Changement formule coût de rétribution sur les lignes de devis en fonction de la référence interne de l'article :
    - si référence interne commence par DSP : remplacer le variable postal (30%) par l'adresse postal DSP (100%)