### PR TITLE
[FIX] maas_website

### DIFF
--- a/maas-addons/maas_website/views/templates.xml
+++ b/maas-addons/maas_website/views/templates.xml
@@ -129,6 +129,7 @@
                                                                 t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
                                                                 t-att-data-default-lang="editable and 'true' if lg[0] == website.default_lang_id.code else None"
                                                                 t-att-data-lang="lg[0]"
+                                                                t-att-data-url_code="lg[1]"
                                                                 class="js_change_lang"
                                                             >
                                                                 <t t-esc="lg[2].split('/').pop()" />
@@ -559,6 +560,7 @@
                                                             t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
                                                             t-att-data-default-lang="editable and 'true' if lg[0] == website.default_lang_id.code else None"
                                                             t-att-data-lang="lg[0]"
+                                                            t-att-data-url_code="lg[1]"
                                                             class="js_change_lang"
                                                         >
 
@@ -1821,6 +1823,7 @@
                                                             t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
                                                             t-att-data-default-lang="editable and 'true' if lg[0] == website.default_lang_id.code else None"
                                                             t-att-data-lang="lg[0]"
+                                                            t-att-data-url_code="lg[1]"
                                                             class="js_change_lang"
                                                         >
                                                             <t t-esc="lg[1].split('/').pop()" />
@@ -2358,6 +2361,7 @@
                                                             t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
                                                             t-att-data-default-lang="editable and 'true' if lg[0] == website.default_lang_id.code else None"
                                                             t-att-data-lang="lg[0]"
+                                                            t-att-data-url_code="lg[1]"
                                                             class="js_change_lang"
                                                         >
                                                             <t t-esc="lg[1].split('/').pop()" />
@@ -2480,6 +2484,7 @@
                                                             t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
                                                             t-att-data-default-lang="editable and 'true' if lg[0] == website.default_lang_id.code else None"
                                                             t-att-data-lang="lg[0]"
+                                                            t-att-data-url_code="lg[1]"
                                                             class="js_change_lang"
                                                         >
                                                             <t t-esc="lg[1].split('/').pop()" />


### PR DESCRIPTION
When the user is not logged in (public user), the href on the button is not set. and if the URL is not defined then the redirection to the language is not done. AND also in the code, data-url_code is not defined. Solution: add t-att-data-url_code="lg[1]"