### PR TITLE
[IMP] Deliver an operation

### DIFF
--- a/choreograph-addons/choreograph_project/models/project_project.py
+++ b/choreograph-addons/choreograph_project/models/project_project.py
@@ -104,10 +104,13 @@ class ProjectProject(models.Model):
         if task_id:
             task_id.update_task_stage(stage_number)
 
+    def _is_compaign(self) -> bool:
+        return bool(self.task_ids.filtered(lambda task: task.task_number in ['45', '50']))
+
     def livery_project(self):
         delivery_task_number = '0'
         if self.stage_id.stage_number == '40':
-            self._update_task_stage('80', '15')
+            self._update_task_stage('80', TODO_TASK_STAGE)
             self.write({'stage_id': self.env.ref('choreograph_project.planning_project_stage_in_progress').id})
             delivery_task_number = '75'
         elif self.stage_id.stage_number == '50':
@@ -118,6 +121,9 @@ class ProjectProject(models.Model):
         self.sale_order_id.delivery_email_to = self.task_ids.filtered(
             lambda t: t.task_number == delivery_task_number).provider_delivery_address
         return self.sale_order_id.action_send_delivery_email(completed_task=delivery_task_number)
+
+    def livery_project_compaign(self):
+        self._update_task_stage('90', TODO_TASK_STAGE)
 
     # def _update_95_to_15_with_commitment_date(self):
     #     task_95 = self.task_ids.filtered(lambda task: task.task_number == '95')

--- a/choreograph-addons/choreograph_sale_project/models/sale_order.py
+++ b/choreograph-addons/choreograph_sale_project/models/sale_order.py
@@ -200,6 +200,8 @@ class SaleOrder(models.Model):
     @check_project_count
     def action_livery_project(self):
         project_id = self.project_ids[0]
+        if project_id._is_compaign():
+            return project_id.livery_project_compaign()
         return project_id.livery_project()
 
     @check_project_count


### PR DESCRIPTION
When you click on the DELIVER button at the estimate / purchase order level:
- Move the "Campaign count" task to the "To do" step
- Move the operation to the "Extraction" step.

This only in the case of a Campaign type operation.

features/HT00838
edit :         choreograph-addons/choreograph_project/models/project_project.py
edit :         choreograph-addons/choreograph_sale_project/models/sale_order.py